### PR TITLE
Simplify build scripts

### DIFF
--- a/build
+++ b/build
@@ -22,10 +22,6 @@ do
       config="$arg"
       ;;
 
-    mono-2.0|2.0)
-      runtime="mono-2.0"
-      ;;
-
     mono-3.5|3.5)
       runtime="mono-3.5"
       ;;
@@ -62,7 +58,6 @@ do
       echo
       echo "  mono-4.0, 4.0  Builds using Mono 4.0 profile (future)"
       echo "  mono-3.5, 3.5  Builds using Mono 3.5 profile (default)"
-      echo "  mono-2.0, 2.0  Builds using Mono 2.0 profile"
       echo
       echo "  clean          Cleans the output directory before building"
       echo "  clean-all      Removes output directories for all runtimes"

--- a/build
+++ b/build
@@ -22,10 +22,6 @@ do
       config="$arg"
       ;;
 
-    mono-1.0|1.0)
-      runtime="mono-1.0"
-      ;;
-
     mono-2.0|2.0)
       runtime="mono-2.0"
       ;;
@@ -67,7 +63,6 @@ do
       echo "  mono-4.0, 4.0  Builds using Mono 4.0 profile (future)"
       echo "  mono-3.5, 3.5  Builds using Mono 3.5 profile (default)"
       echo "  mono-2.0, 2.0  Builds using Mono 2.0 profile"
-      echo "  mono-1.0, 1.0  Builds using Mono 1.0 profile"
       echo
       echo "  clean          Cleans the output directory before building"
       echo "  clean-all      Removes output directories for all runtimes"

--- a/build
+++ b/build
@@ -30,14 +30,6 @@ do
       clean="clean"
       ;;
 
-    clean-all)
-      clean="clean-all"
-      ;;
-
-    tools|all)
-      commands="$commands build-$arg"
-      ;;
-
     test|test45|gui-test|gen-syntax)
       commands="$commands $arg"
       ;;
@@ -56,9 +48,6 @@ do
       echo
       echo "  clean          Cleans the output directory before building"
       echo "  clean-all      Removes output directories for all runtimes"
-      echo
-      echo "  samples        Builds the NUnit samples"
-      echo "  tools          Builds the NUnit tools"
       echo
       echo "  test           Runs tests for a build using the console runner"
       echo "  test45         Run the .NET 4.5 async test assembly tests"

--- a/build
+++ b/build
@@ -26,10 +26,6 @@ do
       runtime="mono-3.5"
       ;;
 
-    mono-4.0|4.0)
-      runtime="mono-4.0"
-      ;;
-
     clean)
       clean="clean"
       ;;
@@ -56,7 +52,6 @@ do
       echo "  debug          Builds debug configuration (default)"
       echo "  release        Builds release configuration"
       echo
-      echo "  mono-4.0, 4.0  Builds using Mono 4.0 profile (future)"
       echo "  mono-3.5, 3.5  Builds using Mono 3.5 profile (default)"
       echo
       echo "  clean          Cleans the output directory before building"
@@ -73,12 +68,8 @@ do
       echo
       echo "Notes:"
       echo
-      echo "  1. The default Mono profile to be used is selected automatically"
-      echo "     by the NAnt script based on the version of Mono installed"
-      echo
-      echo "  2. When building under the 3.5 or higher profile, the 2.0"
-      echo "     runtime version is targeted for NUnit itself. Tests use"
-      echo "     the specified higher level framework."
+      echo "  1. Tne 2.0 runtime version is targeted for NUnit itself." 
+	  echo "     Tests use 3.5 or in some cases 4.5."
       echo   
       exit;
       ;;

--- a/build.bat
+++ b/build.bat
@@ -30,8 +30,6 @@ IF /I "%1" EQU "debug" set CONFIG=debug&goto shift
 IF /I "%1" EQU "release" set CONFIG=release&goto shift
 
 IF /I "%1" EQU "net" set RUNTIME=net&goto shift
-IF /I "%1" EQU "net-1.0" set RUNTIME=net-1.0&goto shift
-IF /I "%1" EQU "net-1.1" set RUNTIME=net-1.1&goto shift
 IF /I "%1" EQU "net-2.0" set RUNTIME=net-2.0&goto shift
 IF /I "%1" EQU "net-3.0" set RUNTIME=net-3.0&goto shift
 IF /I "%1" EQU "net-3.5" set RUNTIME=net-3.5&goto shift
@@ -39,7 +37,6 @@ IF /I "%1" EQU "net-4.0" set RUNTIME=net-4.0&goto shift
 IF /I "%1" EQU "net-4.5" set RUNTIME=net-4.5&goto shift
 
 IF /I "%1" EQU "mono" set RUNTIME=mono&goto shift
-IF /I "%1" EQU "mono-1.0" set RUNTIME=mono-1.0&goto shift
 IF /I "%1" EQU "mono-2.0" set RUNTIME=mono-2.0&goto shift
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
 IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift

--- a/build.bat
+++ b/build.bat
@@ -30,14 +30,11 @@ IF /I "%1" EQU "debug" set CONFIG=debug&goto shift
 IF /I "%1" EQU "release" set CONFIG=release&goto shift
 
 IF /I "%1" EQU "net" set RUNTIME=net&goto shift
-IF /I "%1" EQU "net-2.0" set RUNTIME=net-2.0&goto shift
-IF /I "%1" EQU "net-3.0" set RUNTIME=net-3.0&goto shift
 IF /I "%1" EQU "net-3.5" set RUNTIME=net-3.5&goto shift
 IF /I "%1" EQU "net-4.0" set RUNTIME=net-4.0&goto shift
 IF /I "%1" EQU "net-4.5" set RUNTIME=net-4.5&goto shift
 
 IF /I "%1" EQU "mono" set RUNTIME=mono&goto shift
-IF /I "%1" EQU "mono-2.0" set RUNTIME=mono-2.0&goto shift
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
 IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift
 
@@ -83,13 +80,8 @@ echo.
 echo   net-4.5        Builds using .NET 4.5 framework (future)
 echo   net-4.0        Builds using .NET 4.0 framework (future)
 echo   net-3.5        Builds using .NET 3.5 framework (default)
-echo   net-2.0        Builds using .NET 2.0 framework
-echo   net-1.1        Builds using .NET 1.1 framework
-echo   net-1.0        Builds using .NET 1.0 framework
 echo   mono-4.0       Builds using Mono 4.0 profile (future)
 echo   mono-3.5       Builds using Mono 3.5 profile (default)
-echo   mono-2.0       Builds using Mono 2.0 profile
-echo   mono-1.0       Builds using Mono 1.0 profile
 echo.
 echo   net            Builds using default .NET version
 echo   mono           Builds using default Mono profile

--- a/build.bat
+++ b/build.bat
@@ -31,12 +31,9 @@ IF /I "%1" EQU "release" set CONFIG=release&goto shift
 
 IF /I "%1" EQU "net" set RUNTIME=net&goto shift
 IF /I "%1" EQU "net-3.5" set RUNTIME=net-3.5&goto shift
-IF /I "%1" EQU "net-4.0" set RUNTIME=net-4.0&goto shift
-IF /I "%1" EQU "net-4.5" set RUNTIME=net-4.5&goto shift
 
 IF /I "%1" EQU "mono" set RUNTIME=mono&goto shift
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
-IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift
 
 if /I "%1" EQU "clean" set CLEAN=clean&goto shift
 if /I "%1" EQU "clean-all" set CLEAN=clean-all&goto shift
@@ -77,10 +74,7 @@ echo.
 echo   debug          Builds debug configuration (default)
 echo   release        Builds release configuration
 echo.
-echo   net-4.5        Builds using .NET 4.5 framework (future)
-echo   net-4.0        Builds using .NET 4.0 framework (future)
 echo   net-3.5        Builds using .NET 3.5 framework (default)
-echo   mono-4.0       Builds using Mono 4.0 profile (future)
 echo   mono-3.5       Builds using Mono 3.5 profile (default)
 echo.
 echo   net            Builds using default .NET version
@@ -100,14 +94,10 @@ echo   ?, /h, /help   Displays this help message
 echo.
 echo Notes:
 echo.
-echo   1. The default .NET or Mono version to be used is selected
-echo      automatically by the NAnt script from those installed.
+echo   1. The 2.0 framework is targeted for NUnit itself. Tests use
+echo      .NET 3.5 or (in some cases) 4.5.
 echo.
-echo   2. When building under a framework version of 3.5 or higher,
-echo      the 2.0 framework is targeted for NUnit itself. Tests use
-echo      the specified higher level framework.
-echo.
-echo   3. Any arguments following '--' on the command line are passed
+echo   2. Any arguments following '--' on the command line are passed
 echo      directly to the NAnt script.
 echo.
 

--- a/build.bat
+++ b/build.bat
@@ -36,12 +36,9 @@ IF /I "%1" EQU "mono" set RUNTIME=mono&goto shift
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
 
 if /I "%1" EQU "clean" set CLEAN=clean&goto shift
-if /I "%1" EQU "clean-all" set CLEAN=clean-all&goto shift
-IF /I "%1" EQU "tools" set COMMANDS=%COMMANDS% build-tools&goto shift
 IF /I "%1" EQU "test" set COMMANDS=%COMMANDS% test&goto shift
 IF /I "%1" EQU "test45" set COMMANDS=%COMMANDS% test45&goto shift
 IF /I "%1" EQU "gui-test" set COMMANDS=%COMMANDS% gui-test&goto shift
-IF /I "%1" EQU "gen-syntax" set COMMANDS=%COMMANDS% gen-syntax&goto shift
 
 IF "%1" EQU "--" set PASSTHRU=TRUE&goto shift
 

--- a/package
+++ b/package
@@ -25,10 +25,6 @@ do
       runtime="mono-3.5"
       ;;
 
-    mono-4.0|4.0)
-      runtime="mono-4.0"
-      ;;
-
     src|zip|all)
       commands="$commands package-$arg"
       ;;

--- a/package
+++ b/package
@@ -21,10 +21,6 @@ do
       config="$arg"
       ;;
 
-    mono-2.0|2.0)
-      runtime="mono-2.0"
-      ;;
-
     mono-3.5|3.5)
       runtime="mono-3.5"
       ;;
@@ -53,7 +49,6 @@ do
       echo
       echo "  mono-4.0, 4.0  Builds package using Mono 4.0 profile (future)"
       echo "  mono-3.5, 3.5  Builds package using Mono 3.5 profile (default)"
-      echo "  mono-2.0, 2.0  Builds package using Mono 2.0 profile"
       echo
       echo "  src, source    Builds the source package"
       echo "  zip            Builds a binary package in zipped form"

--- a/package
+++ b/package
@@ -21,10 +21,6 @@ do
       config="$arg"
       ;;
 
-    mono-1.0|1.0)
-      runtime="mono-1.0"
-      ;;
-
     mono-2.0|2.0)
       runtime="mono-2.0"
       ;;
@@ -37,7 +33,7 @@ do
       runtime="mono-4.0"
       ;;
 
-    src|docs|zip|all)
+    src|zip|all)
       commands="$commands package-$arg"
       ;;
 
@@ -58,11 +54,8 @@ do
       echo "  mono-4.0, 4.0  Builds package using Mono 4.0 profile (future)"
       echo "  mono-3.5, 3.5  Builds package using Mono 3.5 profile (default)"
       echo "  mono-2.0, 2.0  Builds package using Mono 2.0 profile"
-      echo "  mono-1.0, 1.0  Builds package using Mono 1.0 profile"
       echo
       echo "  src, source    Builds the source package"
-      echo "  docs           Builds the documentation package"
-      echo "  samples        Builds the nunit samples package"
       echo "  zip            Builds a binary package in zipped form"
       echo "  all            Builds source, documentation, 3.5 and 1.0 packages"
       echo

--- a/package.bat
+++ b/package.bat
@@ -29,14 +29,11 @@ IF /I "%1" EQU "/help"	goto usage
 IF /I "%1" EQU "debug"	set CONFIG=debug&goto shift
 IF /I "%1" EQU "release" set CONFIG=release&goto shift
 
-IF /I "%1" EQU "net-1.0" set RUNTIME=net-1.0&goto shift
-IF /I "%1" EQU "net-1.1" set RUNTIME=net-1.1&goto shift
 IF /I "%1" EQU "net-2.0" set RUNTIME=net-2.0&goto shift
 IF /I "%1" EQU "net-3.0" set RUNTIME=net-3.0&goto shift
 IF /I "%1" EQU "net-3.5" set RUNTIME=net-3.5&goto shift
 IF /I "%1" EQU "net-4.0" set RUNTIME=net-4.0&goto shift
 
-IF /I "%1" EQU "mono-1.0" set RUNTIME=mono-1.0&goto shift
 IF /I "%1" EQU "mono-2.0" set RUNTIME=mono-2.0&goto shift
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
 IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift
@@ -44,7 +41,6 @@ IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift
 IF /I "%1" EQU "check" set CHECK=1&goto shift
 
 IF /I "%1" EQU "all"		set COMMANDS=%COMMANDS% package-all&goto shift
-IF /I "%1" EQU "docs"		set COMMANDS=%COMMANDS% package-docs&goto shift
 IF /I "%1" EQU "source"		set COMMANDS=%COMMANDS% package-src&goto shift
 IF /I "%1" EQU "src"		set COMMANDS=%COMMANDS% package-src&goto shift
 IF /I "%1" EQU "zip"		set COMMANDS=%COMMANDS% package-zip&goto shift
@@ -86,15 +82,11 @@ echo.
 echo   net-4.0        Builds package using .NET 4.0 build (future)
 echo   net-3.5        Builds package using .NET 3.5 build (default)
 echo   net-2.0        Builds package using .NET 2.0 build
-echo   net-1.1        Builds package using .NET 1.1 build
-echo   net-1.0        Builds package using .NET 1.0 build
 echo   mono-4.0       Builds package using Mono 4.0 profile (future)
 echo   mono-3.5       Builds package using Mono 3.5 profile (default)
 echo   mono-2.0       Builds package using Mono 2.0 profile
-echo   mono-1.0       Builds package using Mono 1.0 profile
 echo.
 echo   src, source    Builds the source package
-echo   docs           Builds the documentation package
 echo   zip            Builds a binary package in zipped form
 echo   msi            Builds a windows installer (msi) package
 echo   all            Builds source, documentation, 3.5 and 1.1 packages

--- a/package.bat
+++ b/package.bat
@@ -29,12 +29,9 @@ IF /I "%1" EQU "/help"	goto usage
 IF /I "%1" EQU "debug"	set CONFIG=debug&goto shift
 IF /I "%1" EQU "release" set CONFIG=release&goto shift
 
-IF /I "%1" EQU "net-2.0" set RUNTIME=net-2.0&goto shift
-IF /I "%1" EQU "net-3.0" set RUNTIME=net-3.0&goto shift
 IF /I "%1" EQU "net-3.5" set RUNTIME=net-3.5&goto shift
 IF /I "%1" EQU "net-4.0" set RUNTIME=net-4.0&goto shift
 
-IF /I "%1" EQU "mono-2.0" set RUNTIME=mono-2.0&goto shift
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
 IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift
 
@@ -81,10 +78,8 @@ echo   release        Builds release packages
 echo.
 echo   net-4.0        Builds package using .NET 4.0 build (future)
 echo   net-3.5        Builds package using .NET 3.5 build (default)
-echo   net-2.0        Builds package using .NET 2.0 build
 echo   mono-4.0       Builds package using Mono 4.0 profile (future)
 echo   mono-3.5       Builds package using Mono 3.5 profile (default)
-echo   mono-2.0       Builds package using Mono 2.0 profile
 echo.
 echo   src, source    Builds the source package
 echo   zip            Builds a binary package in zipped form

--- a/package.bat
+++ b/package.bat
@@ -30,10 +30,7 @@ IF /I "%1" EQU "debug"	set CONFIG=debug&goto shift
 IF /I "%1" EQU "release" set CONFIG=release&goto shift
 
 IF /I "%1" EQU "net-3.5" set RUNTIME=net-3.5&goto shift
-IF /I "%1" EQU "net-4.0" set RUNTIME=net-4.0&goto shift
-
 IF /I "%1" EQU "mono-3.5" set RUNTIME=mono-3.5&goto shift
-IF /I "%1" EQU "mono-4.0" set RUNTIME=mono-4.0&goto shift
 
 IF /I "%1" EQU "check" set CHECK=1&goto shift
 
@@ -76,15 +73,13 @@ echo.
 echo   debug          Builds debug packages (default)
 echo   release        Builds release packages
 echo.
-echo   net-4.0        Builds package using .NET 4.0 build (future)
 echo   net-3.5        Builds package using .NET 3.5 build (default)
-echo   mono-4.0       Builds package using Mono 4.0 profile (future)
 echo   mono-3.5       Builds package using Mono 3.5 profile (default)
 echo.
 echo   src, source    Builds the source package
 echo   zip            Builds a binary package in zipped form
 echo   msi            Builds a windows installer (msi) package
-echo   all            Builds source, documentation, 3.5 and 1.1 packages
+echo   all            Builds source, documentation, zip, msi and nuget packages
 echo.
 echo   check          Causes all ICE verifications to run when building
 echo                  the msi, including those normally suppressed.

--- a/scripts/nunit.build.targets
+++ b/scripts/nunit.build.targets
@@ -8,10 +8,6 @@
 <!-- In order to build the msi, WiX 2.0 and the WiX tasks for NAnt     -->
 <!-- are required. To run the test coverage target, NCover is          -->
 <!-- required.                                                         -->
-<!--                                                                   -->
-<!-- Currently, the .NET 1.0 builds of the GUI runner cannot be run    -->
-<!-- successfully. However, the .NET 1.1 builds may be run under 1.0.  -->
-<!--                                                                   -->
 <!-- ***************************************************************** -->
 
 <!-- ***************************************************************** -->
@@ -37,17 +33,6 @@
 
   </target>
 
-  <target name="clean-all" 
-      description="Removes output created by all build configs">
- 
-    <delete dir="${project.build.dir}" 
-      if="${directory::exists( project.build.dir )}"/>
-
-    <delete file="src/GeneratedAssemblyInfo.cs"
-      if="${file::exists( 'src/GeneratedAssemblyInfo.cs' )}"/>
-
-  </target>
-
 <!-- ***************************************************************** -->
 <!-- ***              Targets that generate code                   *** -->
 <!-- ***************************************************************** -->
@@ -63,7 +48,7 @@
         <attribute type="AssemblyCompanyAttribute" value="NUnit.org"/>
         <attribute type="AssemblyProductAttribute" value="NUnit"/>
         <attribute type="AssemblyCopyrightAttribute"
-          value="Copyright (C) 2002-2014, Charlie Poole.&#xD;&#xA;Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.&#xD;&#xA;Copyright (C) 2000-2002 Philip Craig.&#xD;&#xA;All Rights Reserved."/>
+          value="Copyright (C) 2002-2014, 2018 Charlie Poole.&#xD;&#xA;Copyright (C) 2002-2004 James W. Newkirk, Michael C. Two, Alexei A. Vorontsov.&#xD;&#xA;Copyright (C) 2000-2002 Philip Craig.&#xD;&#xA;All Rights Reserved."/>
         <attribute type="AssemblyTrademarkAttribute" value="NUnit is a trademark of NUnit.org"/>
         <attribute type="AssemblyVersionAttribute" value="${internal.version}"/>
         <attribute type="AssemblyInformationalVersionAttribute" value="${internal.version}"/>
@@ -143,20 +128,6 @@
 
   </target>
 
-  <!-- Build current config for all available runtimes -->
-  <target name="build-all"
-      description="Build current config for all available runtimes">
-
-    <foreach item="String" delim="," 
-        property="framework" in="${installed.frameworks}">
-
-      <call target="set-${framework}-runtime-config"/>
-      <call target="build"/>
-
-    </foreach>
-
-  </target>
-
 <!-- ***************************************************************** -->
 <!-- ***                 Targets for running tests                 *** -->
 <!-- ***************************************************************** -->
@@ -211,113 +182,6 @@
 
   </target>
 
-  <target name="test-coverage" depends="build"
-    description="Run tests for a build under NCover to get coverage results">
-
-    <echo message="*"/>
-    <echo message="* Starting ${runtime.config} ${build.config} test coverage run"/>
-    <echo message="*"/>
-
-    <property name="ncover.options" 
-      value="//a nunit.framework;nunit.core;nunit.extensions;nunit.util;nunit.console;nunit.uikit;nunit-gui-runner"/>
-
-    <!-- We use exec rather than the nunit2 task because we are testing
-         a new build of NUnit which is likely not to be included in the Nant build -->
-    <exec basedir="${ncover.dir}"
-          workingdir="${current.build.dir}" 
-	  program="NCover.Console.exe" 
-      managed="strict"
-	  commandline="nunit-console.exe NUnitTests.nunit ${nunit.options} ${ncover.options}"
-	if="${build.win32}" />
-
-    <!-- Mono currently has a SIGSEGV fault if we run in a single AppDomain -->
-         a new build of NUnit which is likely not to be included in the Nant build -->
-    <exec basedir="${ncover.dir}"
-          workingdir="${current.build.dir}" 
-	  program="NCover.Console.exe" 
-          managed="strict"
-	  commandline="nunit-console.exe NUnitTests.nunit ${nunit.options}"
-	unless="${build.win32}" />
-
-  </target>
-
-  <target name="test-all"
-      description="Build and test all runtimes for current config">
-
-    <foreach item="String" delim="," 
-        property="framework" in="${installed.frameworks}">
-
-      <call target="set-${framework}-runtime-config"/>
-      <call target="test" />
-
-    </foreach>
-
-  </target>
-
-  <target name="test-each-runtime" depends="build"
-      description="Run tests for the current build under each runtime">
-
-    <foreach item="String" delim=","
-        property="framework" in="${supported.test.platforms}">
-
-      <if test="${framework::exists( framework )}">
-        <property name="nant.settings.currentframework"
-            value="${framework}" />
-        <call target="run-test" failonerror="false" />
-      </if>
-
-    </foreach>
-
-    <property name="nant.settings.currentframework" value="${runtime.config}" />
-
-    <echo message="*" />
-    <echo message="* Restored runtime to ${nant.settings.currentframework}" />
-    <echo message="*" />
-
-  </target>
-
-  <target name="test-all-under-each"
-      description="Build all runtimes and test the builds under each runtime.">
-
-    <foreach item="String" delim="," 
-        property="framework" in="${installed.frameworks}">
-
-      <call target="set-${framework}-runtime-config"/>
-      <call target="test-each-runtime" failonerror="false"/>
-
-    </foreach>
-
-  </target>
-
-  <target name="nunit2-test" depends="build"
-    description="Run tests for a build using the nunit2 task">
-
-    <echo message="*"/>
-    <echo message="* Starting ${runtime.config} ${build.config} test run"/>
-    <echo message="*"/>
-
-    <nunit2>
-      <formatter type="Plain"/>
-      <test assemblyname="${current.build.dir}/nunit.framework.tests.dll"/>
-    </nunit2>
-  </target>
-
-  <target name="timing-test" depends="build"
-    description="Run timing tests (long)">
-
-    <echo message="*"/>
-    <echo message="* Starting ${runtime.config} ${build.config} timing tests"/>
-    <echo message="*"/>
-    <echo message="* WARNING: Test may take some time to run"/>
-    <echo message="*"/>
-
-    <exec basedir="${current.build.dir}" 
-      workingdir="${current.build.dir}" 
-      program="nunit-console.exe" 
-      commandline="timing-tests.dll"/>
-
-  </target>
-
   <target name="gui-test" depends="build"
     description="Run tests for a build using gui runner">
 
@@ -332,22 +196,6 @@
       commandline="NUnitTests.nunit -run"/>
 
   </target>
-
-  <target name="fit-tests" depends="build"
-    description="Run Fit Acceptance tests on the build">
-
-    <echo message="*"/>
-    <echo message="* Starting ${runtime.config} ${build.config} Fit Tests"/>
-    <echo message="*"/>
-
-    <exec basedir="${current.build.dir}" 
-      workingdir="${current.build.dir}" 
-      program="runfile.exe" 
-      managed="strict"
-      commandline="NUnitFitTests.html TestResults.html ." />
-
-  </target>
-
 
 <!-- ***************************************************************** -->
 <!-- ******              Targets used internally              ******** -->

--- a/scripts/nunit.build.targets
+++ b/scripts/nunit.build.targets
@@ -276,14 +276,6 @@
 
   </target>
 
-  <target name="test-under-net-1.0">
-    <if test="${framework::exists('net-1.0')}">
-      <property name="nant.settings.currentframework" value="net-1.0"/>
-      <call target="run-test"/>
-      <property name="nant.settings.currentframework" value="${runtime.config}" />
-    </if>
-  </target>
-
   <target name="test-all-under-each"
       description="Build all runtimes and test the builds under each runtime.">
 

--- a/scripts/nunit.common.targets
+++ b/scripts/nunit.common.targets
@@ -48,7 +48,7 @@
          The first .NET and Mono frameworks found are the
          respective net and mono defaults. -->
   <property name="supported.frameworks" 
-    value="net-3.5,net-4.0,net-4.5,net-1.1,mono-3.5,mono-4.0"/>
+    value="net-3.5,net-4.0,net-4.5,mono-3.5,mono-4.0"/>
 
   <!-- Packages we normally create -->
   <property name="standard.packages" value="net-3.5" 
@@ -180,28 +180,6 @@
 
   </target>
 
-  <!--<target name="set-net-1.0-runtime-config">
-
-    <property name="runtime.platform" value="net"/>
-    <property name="runtime.version" value="1.0"/>
-    <property name="target.version" value="1.0"/>
-    <property name="runtime.defines" value="MSNET,CLR_1_0,NET_1_0"/>
-    <property name="supported.test.platforms" 
-      value="net-1.0,net-1.1,net-2.0,mono-1.0,mono-2.0"/>
-
-  </target>-->
-	
-  <target name="set-net-1.1-runtime-config">
-
-    <property name="runtime.platform" value="net"/>
-    <property name="runtime.version" value="1.1"/>
-    <property name="target.version" value="1.1"/>
-    <property name="runtime.defines" value="MSNET,CLR_1_1,NET_1_1"/>
-    <property name="supported.test.platforms"
-      value="net-1.0,net-1.1,net-2.0,mono-1.0,mono-2.0"/>
-
-  </target>
-	
   <!--<target name="set-net-2.0-runtime-config">
 
     <property name="runtime.platform" value="net"/>
@@ -242,17 +220,6 @@
 
   </target>
  	
-  <!--<target name="set-mono-1.0-runtime-config">
-
-    <property name="runtime.platform" value="mono"/>
-    <property name="runtime.version" value="1.0"/>
-    <property name="target.version" value="1.0"/>
-    <property name="runtime.defines" value="MONO,CLR_1_1,NET_1_1"/>
-    <property name="supported.test.platforms"
-      value="mono-1.0,mono-2.0,net-1.0,net-1.1,net-2.0"/>
-
-  </target>
-
   <target name="set-mono-2.0-runtime-config">
 
     <property name="runtime.platform" value="mono"/>
@@ -301,10 +268,6 @@
 
   <target name="set-net-2.0-package-config">
     <property name="package.config" value="net-2.0"/>
-  </target>
-
-  <target name="set-net-1.1-package-config">
-    <property name="package.config" value="net-1.1"/>
   </target>
 
 <!-- ***************************************************************** -->

--- a/scripts/nunit.common.targets
+++ b/scripts/nunit.common.targets
@@ -180,16 +180,6 @@
 
   </target>
 
-  <!--<target name="set-net-2.0-runtime-config">
-
-    <property name="runtime.platform" value="net"/>
-    <property name="runtime.version" value="2.0"/>
-    <property name="target.version" value="2.0"/>
-    <property name="runtime.defines" value="MSNET,CLR_2_0,NET_2_0"/>
-    <property name="supported.test.platforms" value="net-2.0,mono-2.0"/>
-
-  </target>-->
-   
   <target name="set-net-3.5-runtime-config">
 
     <property name="runtime.platform" value="net"/>
@@ -220,16 +210,6 @@
 
   </target>
  	
-  <target name="set-mono-2.0-runtime-config">
-
-    <property name="runtime.platform" value="mono"/>
-    <property name="runtime.version" value="2.0"/>
-    <property name="target.version" value="2.0"/>
-    <property name="runtime.defines" value="MONO,CLR_2_0,NET_2_0"/>
-    <property name="supported.test.platforms" value="mono-2.0,net-2.0"/>
-
-  </target>-->
-
 	<target name="set-mono-3.5-runtime-config">
 
 		<property name="runtime.platform" value="mono"/>
@@ -246,7 +226,7 @@
 		<property name="runtime.version" value="4.0"/>
 		<property name="target.version" value="2.0"/>
 		<property name="runtime.defines" value="MONO,CLR_4_0,NET_4_0,CS_4_0"/>
-		<property name="supported.test.platforms" value="mono-4.0,net-4.0,mono-3.5,net-3.5,mono-2.0,net-2.0"/>
+		<property name="supported.test.platforms" value="mono-4.0,net-4.0,mono-3.5,net-3.5"/>
 
 	</target>
 

--- a/scripts/nunit.common.targets
+++ b/scripts/nunit.common.targets
@@ -48,7 +48,7 @@
          The first .NET and Mono frameworks found are the
          respective net and mono defaults. -->
   <property name="supported.frameworks" 
-    value="net-3.5,net-4.0,net-4.5,mono-3.5,mono-4.0"/>
+    value="net-3.5,mono-3.5"/>
 
   <!-- Packages we normally create -->
   <property name="standard.packages" value="net-3.5" 
@@ -190,26 +190,6 @@
 
   </target>
  	
-  <target name="set-net-4.0-runtime-config">
-
-    <property name="runtime.platform" value="net"/>
-    <property name="runtime.version" value="4.0"/>
-    <property name="target.version" value="2.0"/>
-    <property name="runtime.defines" value="MSNET,CLR_4_0,NET_4_0,CS_4_0"/>
-    <property name="supported.test.platforms" value="net-4.0"/>
-
-  </target>
-  
-  <target name="set-net-4.5-runtime-config">
-
-    <property name="runtime.platform" value="net"/>
-    <property name="runtime.version" value="4.5"/>
-    <property name="target.version" value="2.0"/>
-    <property name="runtime.defines" value="MSNET,CLR_4_0,NET_4_5,CS_5_0"/>
-    <property name="supported.test.platforms" value="net-4.5"/>
-
-  </target>
- 	
 	<target name="set-mono-3.5-runtime-config">
 
 		<property name="runtime.platform" value="mono"/>
@@ -220,17 +200,7 @@
 
 	</target>
 
-	<target name="set-mono-4.0-runtime-config">
-
-		<property name="runtime.platform" value="mono"/>
-		<property name="runtime.version" value="4.0"/>
-		<property name="target.version" value="2.0"/>
-		<property name="runtime.defines" value="MONO,CLR_4_0,NET_4_0,CS_4_0"/>
-		<property name="supported.test.platforms" value="mono-4.0,net-4.0,mono-3.5,net-3.5"/>
-
-	</target>
-
-	<!-- ***************************************************************** -->
+<!-- ***************************************************************** -->
 <!-- ***    Targets for setting the package configuration          *** -->
 <!-- ***************************************************************** -->
 

--- a/scripts/nunit.common.targets
+++ b/scripts/nunit.common.targets
@@ -186,7 +186,6 @@
     <property name="runtime.version" value="3.5"/>
     <property name="target.version" value="2.0"/>
     <property name="runtime.defines" value="MSNET,CLR_2_0,NET_3_5,CS_3_0"/>
-    <property name="supported.test.platforms" value="net-3.5,mono-3.5"/>
 
   </target>
  	
@@ -196,7 +195,6 @@
 		<property name="runtime.version" value="3.5"/>
 		<property name="target.version" value="2.0"/>
 		<property name="runtime.defines" value="MONO,CLR_2_0,NET_3_5,CS_3_0"/>
-		<property name="supported.test.platforms" value="mono-3.5,net-3.5,mono-2.0,net-2.0"/>
 
 	</target>
 
@@ -214,10 +212,6 @@
 
   <target name="set-net-3.5-package-config">
     <property name="package.config" value="net-3.5"/>
-  </target>
-
-  <target name="set-net-2.0-package-config">
-    <property name="package.config" value="net-2.0"/>
   </target>
 
 <!-- ***************************************************************** -->
@@ -321,9 +315,6 @@
     <echo>  Runtime:   ${runtime.config}</echo>
     <echo>  Build Dir: ${current.build.dir}</echo>
     <echo>  Defines:   ${build.defines}</echo>
-    <echo></echo>
-    <echo>Test Platforms for Current Build</echo>
-    <echo>  Supported: ${supported.test.platforms}</echo>
     <echo></echo>
     <echo>Packaging</echo>
     <echo>  Base Name: ${package.base.name}</echo>

--- a/scripts/nunit.package.targets
+++ b/scripts/nunit.package.targets
@@ -8,10 +8,6 @@
 <!-- In order to build the msi, WiX 2.0 and the WiX tasks for NAnt     -->
 <!-- are required. To run the test coverage target, NCover is          -->
 <!-- required.                                                         -->
-<!--                                                                   -->
-<!-- Currently, the .NET 1.0 builds of the GUI runner cannot be run    -->
-<!-- successfully. However, the .NET 1.1 builds may be run under 1.0.  -->
-<!--                                                                   -->
 <!-- ***************************************************************** -->
 
 <!-- ***************************************************************** -->

--- a/scripts/nunit.package.targets
+++ b/scripts/nunit.package.targets
@@ -168,9 +168,7 @@
       </defines>
       <sources basedir="${install.dir}">
         <include name="NUnit.wxs" if="${runtime.version >= '2.0'}"/>
-        <include name="NUnit-net-1.1.wxs" unless="${runtime.version >= '2.0'}"/>
         <include name="base.wxs" if="${runtime.version >= '2.0'}"/>
-        <include name="base-net-1.1.wxs" unless="${runtime.version >= '2.0'}"/>
         <include name="tests.wxs" />
         <include name="pnunit.wxs" />
         <include name="nunit-gui.wxs" if="${runtime.version >= '2.0'}"/>
@@ -185,9 +183,7 @@
       extensions="WixUIExtension">
       <sources>
         <include name="${work.dir}/NUnit.wixobj" if="${runtime.version >= '2.0'}"/>
-        <include name="${work.dir}/NUnit-net-1.1.wixobj" unless="${runtime.version >= '2.0'}"/>
         <include name="${work.dir}/base.wixobj" if="${runtime.version >= '2.0'}"/>
-        <include name="${work.dir}/base-net-1.1.wixobj" unless="${runtime.version >= '2.0'}"/>
         <include name="${work.dir}/tests.wixobj" />
         <include name="${work.dir}/pnunit.wixobj" />
         <include name="${work.dir}/nunit-gui.wixobj" if="${runtime.version >= '2.0'}"/>


### PR DESCRIPTION
Fixes #37 

Build scripts now only have the targets we actually use. This is in preparation for replacing the scripts with use of a Cake build script that performs the same tasks.