### PR TITLE
Detect TestCase.Result usage in all versions of NUnit V2

### DIFF
--- a/src/NUnitCore/core/Builders/LegacySuiteBuilder.cs
+++ b/src/NUnitCore/core/Builders/LegacySuiteBuilder.cs
@@ -89,13 +89,13 @@ namespace NUnit.Core.Builders
                 return false;
             }
 
-            if (!NUnitFramework.CheckSetUpTearDownMethods(type, NUnitFramework.FixtureSetUpAttribute, ref reason))
+            if (!NUnitFramework.CheckSetUpTearDownMethods(type, NUnitFramework.TestFixtureSetUpAttribute, ref reason))
                 return false;
 
             if (!NUnitFramework.CheckSetUpTearDownMethods(type, NUnitFramework.OneTimeSetUpAttribute, ref reason))
                 return false;
 
-            if (!NUnitFramework.CheckSetUpTearDownMethods(type, NUnitFramework.FixtureTearDownAttribute, ref reason))
+            if (!NUnitFramework.CheckSetUpTearDownMethods(type, NUnitFramework.TestFixtureTearDownAttribute, ref reason))
                 return false;
 
             if (!NUnitFramework.CheckSetUpTearDownMethods(type, NUnitFramework.OneTimeTearDownAttribute, ref reason))

--- a/src/NUnitCore/core/Builders/NUnitTestFixtureBuilder.cs
+++ b/src/NUnitCore/core/Builders/NUnitTestFixtureBuilder.cs
@@ -271,9 +271,9 @@ namespace NUnit.Core.Builders
 
             return NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.SetUpAttribute, ref reason)
                 && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.TearDownAttribute, ref reason)
-                && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.FixtureSetUpAttribute, ref reason)
+                && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.TestFixtureSetUpAttribute, ref reason)
                 && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.OneTimeSetUpAttribute, ref reason)
-                && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.FixtureTearDownAttribute, ref reason)
+                && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.TestFixtureTearDownAttribute, ref reason)
                 && NUnitFramework.CheckSetUpTearDownMethods(fixtureType, NUnitFramework.OneTimeTearDownAttribute, ref reason);
         }
 

--- a/src/NUnitCore/core/Builders/SetUpFixtureBuilder.cs
+++ b/src/NUnitCore/core/Builders/SetUpFixtureBuilder.cs
@@ -57,13 +57,13 @@ namespace NUnit.Core.Builders
                 return false;
             }
 
-            if ( Reflect.HasMethodWithAttribute(type, NUnitFramework.FixtureSetUpAttribute, true) )
+            if ( Reflect.HasMethodWithAttribute(type, NUnitFramework.TestFixtureSetUpAttribute, true) )
             {
                 reason = "TestFixtureSetUp method not allowed on a SetUpFixture";
                 return false;
             }
 
-            if ( Reflect.HasMethodWithAttribute(type, NUnitFramework.FixtureTearDownAttribute, true) )
+            if ( Reflect.HasMethodWithAttribute(type, NUnitFramework.TestFixtureTearDownAttribute, true) )
             {
                 reason = "TestFixtureTearDown method not allowed on a SetUpFixture";
                 return false;

--- a/src/NUnitCore/core/Compatibility.cs
+++ b/src/NUnitCore/core/Compatibility.cs
@@ -147,44 +147,47 @@ namespace NUnit.Core
 
                 switch (attributeFullName)
                 {
-                    case "NUnit.Framework.ExpectedExceptionAttribute":
+                    case NUnitFramework.ExpectedExceptionAttribute:
                         Error(location, "ExpectedExceptionAttribute is not supported in NUnit 3. Use Assert.Throws or Throws.InstanceOf.");
                         break;
-                    case "NUnit.Framework.IgnoreAttribute":
-                        var reason = (string)Reflect.GetPropertyValue(attribute, "Reason");
+                    case NUnitFramework.IgnoreAttribute:
+                        var reason = (string)Reflect.GetPropertyValue(attribute, PropertyNames.Reason);
                         if (string.IsNullOrEmpty(reason))
                             Error(location, "IgnoreAttribute must have a reason specified in NUnit 3.");
                         break;
-                    case "NUnit.Framework.RequiresSTAAttribute":
-                    case "NUnit.Framework.RequiresMTAAttribute":
+                    case NUnitFramework.RequiresSTAAttribute:
+                    case NUnitFramework.RequiresMTAAttribute:
                         Error(location, attributeName + " is not supported in NUnit 3. Use ApartmentAttribute.");
                         break;
                     case "NUnit.Core.Extensibility.NUnitAddinAttribute":
-                    case "NUnit.Framework.RequiredAddinAttribute":
+                    case NUnitFramework.RequiredAddinAttribute:
                         Error(location, attributeName + " is not available in NUnit 3, which no longer supports Addins. After conversion, you can create custom attributes or engine extensions instead.");
                         break;
-                    case "NUnit.Framework.SuiteAttribute":
+                    case NUnitFramework.SuiteAttribute:
                         Error(location, "SuiteAttribute is not supported in NUnit 3. You should restructure your tests to eliminate legacy Suites.");
                         break;
-                    case "NUnit.Framework.SetUpAttribute":
-                    case "NUnit.Framework.TearDownAttribute":
+                    case NUnitFramework.SetUpAttribute:
+                    case NUnitFramework.TearDownAttribute:
                         if (methodInfo != null && methodInfo.ReflectedType != null &&
-                            Reflect.HasAttribute(methodInfo.ReflectedType, "NUnit.Framework.SetUpFixtureAttribute", true))
+                            Reflect.HasAttribute(methodInfo.ReflectedType, NUnitFramework.SetUpFixtureAttribute, true))
                         {
                             var replacement = "OneTime" + attributeName;
                             Error(location, attributeName + " is no longer allowed in a SetUpFixture in NUnit 3. Use " + replacement + ".");
                         }
                         break;
-                    case "NUnit.Framework.TestCaseAttribute":
-                        string expectedExceptionName = (string)Reflect.GetPropertyValue(attribute, "ExpectedExceptionName");
+                    case NUnitFramework.TestCaseAttribute:
+                        string expectedExceptionName = (string)Reflect.GetPropertyValue(attribute, PropertyNames.ExpectedExceptionName);
                         if (!string.IsNullOrEmpty(expectedExceptionName))
                             Error(location, "TestCaseAttribute does not support ExpectedException in NUnit 3. Use Assert.Throws or Throws.InstanceOf.");
 
+                        // NUnit 2.6.5+ has LegacyResultUsed property for compatibility testing.
+                        // The HasExpectedResult property was introduced in 2.
                         var legacyResultProp = Reflect.GetNamedProperty(attributeType, "LegacyResultUsed", BindingFlags.Instance | BindingFlags.NonPublic);
-                        var hasExpectedResultProp = Reflect.GetNamedProperty(attributeType, "HasExpectedResult", BindingFlags.Instance | BindingFlags.Public);
-                        bool resultPropertyError = legacyResultProp != null // NUnit 2.6.5+
+                        // Property present in NUnit 2.6.0+
+                        var hasExpectedResultProp = Reflect.GetNamedProperty(attributeType, PropertyNames.HasExpectedResult, BindingFlags.Instance | BindingFlags.Public);
+                        bool resultPropertyError = legacyResultProp != null
                            ? (bool)legacyResultProp.GetValue(attribute, null)
-                           : hasExpectedResultProp != null // NUnit 2.6.0+
+                           : hasExpectedResultProp != null
                                ? (bool)hasExpectedResultProp.GetValue(attribute, null)
                                : Reflect.GetPropertyValue(attribute, "Result") != null;
 
@@ -195,7 +198,7 @@ namespace NUnit.Core
                         if (ignoreUsed != null && (bool)ignoreUsed)
                             Error(location, "TestCaseAttribute Ignore property changes from bool to string in NUnit 3. Fix after conversion.");
                         break;
-                    case "NUnit.Framework.TestCaseSourceAttribute":
+                    case NUnitFramework.TestCaseSourceAttribute:
                         string sourceName = (string)Reflect.GetPropertyValue(attribute, "SourceName");
                         if (!string.IsNullOrEmpty(sourceName))
                         {
@@ -210,18 +213,18 @@ namespace NUnit.Core
                             }
                         }
                         break;
-                    case "NUnit.Framework.TestFixtureAttribute":
+                    case NUnitFramework.TestFixtureAttribute:
                         object ignore = Reflect.GetPropertyValue(attribute, "Ignore");
                         if (ignore != null && (bool)ignore)
                             Error(location, "TestFixtureAttribute Ignore property changes from bool to string in NUnit 3. Fix after conversion.");
                         break;
-                    case "NUnit.Framework.TestFixtureSetUpAttribute":
+                    case NUnitFramework.TestFixtureSetUpAttribute:
                         Error(location, "TestFixtureSetUpAttribute is not supported in NUnit 3. Use OneTimeSetUpAttribute.");
                         break;
-                    case "NUnit.Framework.TestFixtureTearDownAttribute":
+                    case NUnitFramework.TestFixtureTearDownAttribute:
                         Error(location, "TestFixtureTearDownAttribute is not supported in NUnit 3. Use OneTimeTearDownAttribute.");
                         break;
-                    case "NUnit.Framework.ValueSourceAttribute":
+                    case NUnitFramework.ValueSourceAttribute:
                         sourceName = (string)Reflect.GetPropertyValue(attribute, "SourceName");
                         if (!string.IsNullOrEmpty(sourceName))
                         {
@@ -237,8 +240,8 @@ namespace NUnit.Core
                         }
                         break;
 
-                    case "System.STAThreadAttribute":
-                    case "System.MTAThreadAttribute":
+                    case NUnitFramework.STAThreadAttribute:
+                    case NUnitFramework.MTAThreadAttribute:
                         Warning(location, attributeFullName + " has no effect in NUnit 3. Use ApartmentAttribute.");
                         break;
                 }

--- a/src/NUnitCore/core/LegacySuite.cs
+++ b/src/NUnitCore/core/LegacySuite.cs
@@ -19,9 +19,9 @@ namespace NUnit.Core
         public LegacySuite( Type fixtureType ) : base( fixtureType )
         {
             this.FixtureSetUpMethods =
-                Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.FixtureSetUpAttribute, true);
+                Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.TestFixtureSetUpAttribute, true);
             this.FixtureTearDownMethods =
-                Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.FixtureTearDownAttribute, true);
+                Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.TestFixtureTearDownAttribute, true);
         }
     }
 }

--- a/src/NUnitCore/core/NUnitFramework.cs
+++ b/src/NUnitCore/core/NUnitFramework.cs
@@ -35,6 +35,8 @@ namespace NUnit.Core
         public const string PropertyAttribute = "NUnit.Framework.PropertyAttribute";
         public const string DescriptionAttribute = "NUnit.Framework.DescriptionAttribute";
         public const string RequiredAddinAttribute = "NUnit.Framework.RequiredAddinAttribute";
+        public const string RequiresSTAAttribute = "NUnit.Framework.RequiresSTAAttribute";
+        public const string RequiresMTAAttribute = "NUnit.Framework.RequiresMTAAttribute";
 
         // Attributes that apply only to Classes
         public const string TestFixtureAttribute = "NUnit.Framework.TestFixtureAttribute";
@@ -45,16 +47,24 @@ namespace NUnit.Core
         public const string TestCaseAttribute = "NUnit.Framework.TestCaseAttribute";
         public const string TestCaseSourceAttribute = "NUnit.Framework.TestCaseSourceAttribute";
         public const string TheoryAttribute = "NUnit.Framework.TheoryAttribute";
-        public static readonly string SetUpAttribute = "NUnit.Framework.SetUpAttribute";
-        public static readonly string TearDownAttribute = "NUnit.Framework.TearDownAttribute";
-        public static readonly string FixtureSetUpAttribute = "NUnit.Framework.TestFixtureSetUpAttribute";
-        public static readonly string FixtureTearDownAttribute = "NUnit.Framework.TestFixtureTearDownAttribute";
-        public static readonly string OneTimeSetUpAttribute = "NUnit.Framework.OneTimeSetUpAttribute";
-        public static readonly string OneTimeTearDownAttribute = "NUnit.Framework.OneTimeTearDownAttribute";
-        public static readonly string ExpectedExceptionAttribute = "NUnit.Framework.ExpectedExceptionAttribute";
+        public const string SetUpAttribute = "NUnit.Framework.SetUpAttribute";
+        public const string TearDownAttribute = "NUnit.Framework.TearDownAttribute";
+        public const string TestFixtureSetUpAttribute = "NUnit.Framework.TestFixtureSetUpAttribute";
+        public const string TestFixtureTearDownAttribute = "NUnit.Framework.TestFixtureTearDownAttribute";
+        public const string OneTimeSetUpAttribute = "NUnit.Framework.OneTimeSetUpAttribute";
+        public const string OneTimeTearDownAttribute = "NUnit.Framework.OneTimeTearDownAttribute";
+        public const string ExpectedExceptionAttribute = "NUnit.Framework.ExpectedExceptionAttribute";
 
         // Attributes that apply only to Properties
-        public static readonly string SuiteAttribute = "NUnit.Framework.SuiteAttribute";
+        public const string SuiteAttribute = "NUnit.Framework.SuiteAttribute";
+
+        // Attributes that apply only to Parameters
+        public const string ValueSourceAttribute = "NUnit.Framework.ValueSourceAttribute";
+
+        // System attributes used by NUnit
+        public const string STAThreadAttribute = "System.STAThreadAttribute";
+        public const string MTAThreadAttribute = "System.MTAThreadAttribute";
+
         #endregion
 
         #region Other Framework Types
@@ -222,10 +232,10 @@ namespace NUnit.Core
                             test.IgnoreReason = string.Format("Required addin {0} not available", required);
                         }
                         break;
-                    case "System.STAThreadAttribute":
+                    case STAThreadAttribute:
                         test.Properties.Add("APARTMENT_STATE", System.Threading.ApartmentState.STA);
                         break;
-                    case "System.MTAThreadAttribute":
+                    case MTAThreadAttribute:
                         test.Properties.Add("APARTMENT_STATE", System.Threading.ApartmentState.MTA);
                         break;
                     default:

--- a/src/NUnitCore/core/NUnitTestFixture.cs
+++ b/src/NUnitCore/core/NUnitTestFixture.cs
@@ -24,12 +24,12 @@ namespace NUnit.Core
         {
 
             var fixtureSetUpMethods = new List<MethodInfo>();
-            fixtureSetUpMethods.AddRange(Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.FixtureSetUpAttribute, true));
+            fixtureSetUpMethods.AddRange(Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.TestFixtureSetUpAttribute, true));
             fixtureSetUpMethods.AddRange(Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.OneTimeSetUpAttribute, true));
             FixtureSetUpMethods = fixtureSetUpMethods;
 
             var fixtureTearDownMethods = new List<MethodInfo>();
-            fixtureTearDownMethods.AddRange(Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.FixtureTearDownAttribute, true));
+            fixtureTearDownMethods.AddRange(Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.TestFixtureTearDownAttribute, true));
             fixtureTearDownMethods.AddRange(Reflect.GetMethodsWithAttribute(fixtureType, NUnitFramework.OneTimeTearDownAttribute, true));
             FixtureTearDownMethods = fixtureTearDownMethods;
 


### PR DESCRIPTION
Fixes #58 

For versions starting with 2.6.5 we look at the LegacyResultUsed property, which was added for this purpose. For 2.6.0 through 2.6.4, we look at the HasExpectedResult property and for earlier ones at the Result property.