### PR TITLE
Only look for nunit.framework version 2 assemblies

### DIFF
--- a/src/NUnitCore/core/NUnitFramework.cs
+++ b/src/NUnitCore/core/NUnitFramework.cs
@@ -100,12 +100,15 @@ namespace NUnit.Core
             {
                 if (!frameworkAssemblyInitialized)
                     foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
-                        if (assembly.GetName().Name == "nunit.framework" ||
-                            assembly.GetName().Name == "NUnitLite")
+                    {
+                        AssemblyName name = assembly.GetName();
+                        if (name.Name == "nunit.framework" && name.Version.Major == 2 ||
+                            name.Name == "NUnitLite" && name.Version.Major == 1)
                         {
                             frameworkAssembly = assembly;
                             break;
                         }
+                    }
 
                 frameworkAssemblyInitialized = true;
 


### PR DESCRIPTION
This is necessary in a mixed nunit 3 and nunit 2 situation where nunit 3 was loaded first. Otherwise, no nunit 2 test actions will work (and there may be other problems as well), since the nunit 2 engine finds the nunit 3 framework assembly and thinks it's for nunit 2.

NUnit 3 handles this case correctly already.